### PR TITLE
Update Chome extension manifest and action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 node_modules
 tmp
 .env*
+.idea
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -6021,10 +6021,13 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -9283,9 +9286,9 @@
       "dev": true
     },
     "node_modules/global-dirs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
       "dev": true,
       "dependencies": {
         "ini": "2.0.0"
@@ -9373,9 +9376,9 @@
       }
     },
     "node_modules/got": {
-      "version": "12.5.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.5.2.tgz",
-      "integrity": "sha512-guHGMSEcsA5m1oPRweXUJnug0vuvlkX9wx5hzOka+ZBrBUOJHU0Z1JcNu3QE5IPGnA5aXUsQHdWOD4eJg9/v3A==",
+      "version": "12.5.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.5.3.tgz",
+      "integrity": "sha512-8wKnb9MGU8IPGRIo+/ukTy9XLJBwDiCpIf5TVzQ9Cpol50eMTpBq2GAuDsuDIz7hTYmZgMgC1e9ydr6kSDWs3w==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
@@ -9854,9 +9857,9 @@
       }
     },
     "node_modules/http2-wrapper": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
-      "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -10547,9 +10550,9 @@
       }
     },
     "node_modules/is-yarn-global": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.0.tgz",
-      "integrity": "sha512-HneQBCrXGBy15QnaDfcn6OLoU8AQPAa0Qn0IeJR/QCo4E8dNZaGGwxpCwWyEBQC5QvFonP8d6t60iGpAHVAfNA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz",
+      "integrity": "sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -13132,9 +13135,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.1.tgz",
-      "integrity": "sha512-DONNzZ8b9FLIRIX8kF+JByejgBoGUD4msUvRlHnPMqTb49MwW3thKgB6yGsshzOLW0Bol6SGu5TysvSsM6apdA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -13311,9 +13314,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -14316,9 +14319,9 @@
       "dev": true
     },
     "node_modules/node-sass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
-      "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.1.tgz",
+      "integrity": "sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -14334,7 +14337,7 @@
         "node-gyp": "^8.4.1",
         "npmlog": "^5.0.0",
         "request": "^2.88.0",
-        "sass-graph": "^4.0.1",
+        "sass-graph": "4.0.0",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       },
@@ -16504,14 +16507,14 @@
       }
     },
     "node_modules/sass-graph": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.1.tgz",
-      "integrity": "sha512-5YCfmGBmxoIRYHnKK2AKzrAkCoQ8ozO+iumT8K4tXJXRVCPf+7s1/9KxTSW3Rbvf+7Y7b4FR3mWyLnQr3PHocA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.0.tgz",
+      "integrity": "sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
         "lodash": "^4.17.11",
-        "scss-tokenizer": "^0.4.3",
+        "scss-tokenizer": "^0.3.0",
         "yargs": "^17.2.1"
       },
       "bin": {
@@ -16521,42 +16524,28 @@
         "node": ">=12"
       }
     },
-    "node_modules/sass-graph/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/sass-graph/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
+      "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
       "dev": true,
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/sass-graph/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -16637,19 +16626,19 @@
       }
     },
     "node_modules/scss-tokenizer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.4.3.tgz",
-      "integrity": "sha512-raKLgf1LI5QMQnG+RxHz6oK0sL3x3I4FN2UDLqgLOGO8hodECNnNh5BXn7fAyBxrA8zVzdQizQ6XjNJQ+uBwMw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.3.0.tgz",
+      "integrity": "sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==",
       "dev": true,
       "dependencies": {
-        "js-base64": "^2.4.9",
-        "source-map": "^0.7.3"
+        "js-base64": "^2.4.3",
+        "source-map": "^0.7.1"
       }
     },
     "node_modules/scss-tokenizer/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -21312,9 +21301,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -24603,9 +24592,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -27090,9 +27079,9 @@
       "dev": true
     },
     "global-dirs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
       "dev": true,
       "requires": {
         "ini": "2.0.0"
@@ -27155,9 +27144,9 @@
       }
     },
     "got": {
-      "version": "12.5.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.5.2.tgz",
-      "integrity": "sha512-guHGMSEcsA5m1oPRweXUJnug0vuvlkX9wx5hzOka+ZBrBUOJHU0Z1JcNu3QE5IPGnA5aXUsQHdWOD4eJg9/v3A==",
+      "version": "12.5.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.5.3.tgz",
+      "integrity": "sha512-8wKnb9MGU8IPGRIo+/ukTy9XLJBwDiCpIf5TVzQ9Cpol50eMTpBq2GAuDsuDIz7hTYmZgMgC1e9ydr6kSDWs3w==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^5.2.0",
@@ -27518,9 +27507,9 @@
       }
     },
     "http2-wrapper": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
-      "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
@@ -27996,9 +27985,9 @@
       }
     },
     "is-yarn-global": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.0.tgz",
-      "integrity": "sha512-HneQBCrXGBy15QnaDfcn6OLoU8AQPAa0Qn0IeJR/QCo4E8dNZaGGwxpCwWyEBQC5QvFonP8d6t60iGpAHVAfNA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz",
+      "integrity": "sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==",
       "dev": true
     },
     "isarray": {
@@ -29944,9 +29933,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.1.tgz",
-      "integrity": "sha512-DONNzZ8b9FLIRIX8kF+JByejgBoGUD4msUvRlHnPMqTb49MwW3thKgB6yGsshzOLW0Bol6SGu5TysvSsM6apdA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dev": true,
       "requires": {
         "json-buffer": "3.0.1"
@@ -30094,9 +30083,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -30879,9 +30868,9 @@
       "dev": true
     },
     "node-sass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
-      "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.1.tgz",
+      "integrity": "sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -30896,7 +30885,7 @@
         "node-gyp": "^8.4.1",
         "npmlog": "^5.0.0",
         "request": "^2.88.0",
-        "sass-graph": "^4.0.1",
+        "sass-graph": "4.0.0",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       },
@@ -32515,47 +32504,36 @@
       }
     },
     "sass-graph": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.1.tgz",
-      "integrity": "sha512-5YCfmGBmxoIRYHnKK2AKzrAkCoQ8ozO+iumT8K4tXJXRVCPf+7s1/9KxTSW3Rbvf+7Y7b4FR3mWyLnQr3PHocA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.0.tgz",
+      "integrity": "sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.17.11",
-        "scss-tokenizer": "^0.4.3",
+        "scss-tokenizer": "^0.3.0",
         "yargs": "^17.2.1"
       },
       "dependencies": {
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "yargs": {
-          "version": "17.6.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "version": "17.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
+          "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
           "dev": true,
           "requires": {
-            "cliui": "^8.0.1",
+            "cliui": "^7.0.2",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
             "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
+            "yargs-parser": "^21.0.0"
           }
         },
         "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -32597,19 +32575,19 @@
       }
     },
     "scss-tokenizer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.4.3.tgz",
-      "integrity": "sha512-raKLgf1LI5QMQnG+RxHz6oK0sL3x3I4FN2UDLqgLOGO8hodECNnNh5BXn7fAyBxrA8zVzdQizQ6XjNJQ+uBwMw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.3.0.tgz",
+      "integrity": "sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==",
       "dev": true,
       "requires": {
-        "js-base64": "^2.4.9",
-        "source-map": "^0.7.3"
+        "js-base64": "^2.4.3",
+        "source-map": "^0.7.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
       }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -16,7 +16,7 @@ function onMessageHandler(request: any, _sender: chrome.runtime.MessageSender, _
 /*
   A callback URL will only be available if the browser has been launched from ZAP, otherwise call the individual endpoints
 */
-function zapApiUrl(zapurl: string, action: string) {
+function zapApiUrl(zapurl: string, action: string): string {
 	if (zapurl.indexOf('/zapCallBackUrl/') > 0) {
 		return zapurl;
 	} else {
@@ -63,7 +63,11 @@ function onToolbarButtonClick(_tab: any) {
 	chrome.runtime.openOptionsPage();
 }
 
-chrome.browserAction.onClicked.addListener(onToolbarButtonClick);
+if ('browserAction' in chrome) {
+	chrome.browserAction.onClicked.addListener(onToolbarButtonClick);
+} else {
+	chrome.action.onClicked.addListener(onToolbarButtonClick);
+}
 chrome.runtime.onMessage.addListener(onMessageHandler);
 
 export { handleMessage }

--- a/src/manifest/base/v2.js
+++ b/src/manifest/base/v2.js
@@ -14,7 +14,7 @@ module.exports = {
   name,
   short_name,
   description,
-  permissions: [...permissions, "https://*/*"],
+  permissions: [...permissions, "https://*/*", "http://*/*"],
   browser_action: {
     "default_title": short_name
   },

--- a/src/manifest/permissions.js
+++ b/src/manifest/permissions.js
@@ -1,8 +1,6 @@
 // https://developer.chrome.com/docs/extensions/mv3/declare_permissions/
 
 module.exports = [
-  "http://*/",
-  "https://*/",
   // "activeTab",
   // "alarms",
   // "background",


### PR DESCRIPTION
Changes:
- Updated `chrome.browserActions` by `chrome.actions` based on this: https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/#api-browser-action-manifest
- Removed permissions not needed anymore because they are granted by `host_permissions` in `v3`

Before fix:
![Captura de Pantalla 2022-11-04 a la(s) 18 34 50](https://user-images.githubusercontent.com/3411089/200078724-648eadf8-0ddd-4ef0-be7f-1112e9f553e8.png)
![Captura de Pantalla 2022-11-04 a la(s) 18 34 42](https://user-images.githubusercontent.com/3411089/200078749-3a941296-c05c-4a22-b56e-7f61505b661a.png)


After Fix:
![Captura de Pantalla 2022-11-04 a la(s) 18 33 34](https://user-images.githubusercontent.com/3411089/200078785-637b751b-7c0a-4807-b275-ab440df5f21a.png)
![Captura de Pantalla 2022-11-04 a la(s) 18 33 41](https://user-images.githubusercontent.com/3411089/200078799-e34b92a4-e2d9-4446-9a12-1335f0a02514.png)

fixes #20 