### PR TITLE
fixed browser crashing issue

### DIFF
--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -215,7 +215,7 @@ function enableExtension(): void {
 
   const observer = new MutationObserver(domMutated);
   observer.observe(document, {
-    attributes: true,
+    attributes: false,
     childList: true,
     subtree: true,
   });


### PR DESCRIPTION
fixes #46 issue

Earlier we were observing all the attributes changes. 
Now I have disabled that flag and in future if we need to watch for certain attributes we can enable it again and filter the necessary mutations. 