### PR TITLE
Fix chrome link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Only Firefox and Chrome have been tested - Opera may or may not work :wink:
 The latest published extensions are also available via the relevant stores:
 
 * Firefox [ZAP Browser Extension](https://addons.mozilla.org/en-GB/firefox/addon/zap-browser-extension/)
-* Chrome [ZAP Browser Extension](https://chrome.google.com/webstore/detail/zap-browser-extension/oeadiegekjdlhpooeidmimgnmbfllehp)
+* Chrome [ZAP Browser Extension](https://chrome.google.com/webstore/detail/zap-browser-extension/cnmficmodhagepcmhogkbdakncebckho)
 
 ## Quick Start
 


### PR DESCRIPTION
The links are version specific, and I cant find a way to get a fixed URL :/
The prev link was to a version that was removed..