### PR TITLE
Poll for storage changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+- Poll for storage changes.
+
 ## 0.0.7 - 2023-10-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Then run the following:
 - `yarn run build:firefox` to build firefox addon
 - `yarn run build:opera` to build opera extension
 - `yarn run build` builds and packs extensions all at once to extension/ directory
+- `yarn run lint` to lint the code
+- `yarn run test` to run the test suite (you should not have anything listening on port 8080)
 
 ### Development
 

--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -234,6 +234,11 @@ function enableExtension(): void {
     subtree: true,
   });
 
+  setInterval(() => {
+    // Have to poll to pickup storage changes in a timely fashion
+    reportAllStorage();
+  }, 500);
+
   // This is needed for more traditional apps
   reportPageLoaded(document, reportObject);
 }

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -300,9 +300,8 @@ function integrationTests(
       await page.close();
       // Then
       const expectedData =
-        '["{\\"action\\":{\\"action\\":\\"reportEvent\\"},\\"body\\":{\\"eventJson\\":\\"{TIMESTAMP,\\"eventName\\":\\"pageLoad\\",\\"url\\":\\"http://localhost:1801/webpages/localStorage.html\\",\\"count\\":1}\\",\\"apikey\\":\\"not set\\"}}",' +
-        '"{\\"action\\":{\\"action\\":\\"reportObject\\"},\\"body\\":{\\"objectJson\\":\\"{TIMESTAMP,\\"type\\":\\"localStorage\\",\\"tagName\\":\\"\\",\\"id\\":\\"test\\",\\"nodeName\\":\\"\\",\\"url\\":\\"http://localhost:1801/webpages/localStorage.html\\",\\"text\\":\\"localData\\"}\\",\\"apikey\\":\\"not set\\"}}"]';
-      expect(JSON.stringify(Array.from(actualData))).toBe(expectedData);
+        '"{\\"action\\":{\\"action\\":\\"reportObject\\"},\\"body\\":{\\"objectJson\\":\\"{TIMESTAMP,\\"type\\":\\"localStorage\\",\\"tagName\\":\\"\\",\\"id\\":\\"test\\",\\"nodeName\\":\\"\\",\\"url\\":\\"http://localhost:1801/webpages/localStorage.html\\",\\"text\\":\\"localData\\"}\\",\\"apikey\\":\\"not set\\"}}"';
+      expect(JSON.stringify(Array.from(actualData))).toContain(expectedData);
     });
 
     test('Should record set sessionStorage', async () => {
@@ -318,9 +317,44 @@ function integrationTests(
       await page.close();
       // Then
       const expectedData =
-        '["{\\"action\\":{\\"action\\":\\"reportEvent\\"},\\"body\\":{\\"eventJson\\":\\"{TIMESTAMP,\\"eventName\\":\\"pageLoad\\",\\"url\\":\\"http://localhost:1801/webpages/sessionStorage.html\\",\\"count\\":1}\\",\\"apikey\\":\\"not set\\"}}",' +
-        '"{\\"action\\":{\\"action\\":\\"reportObject\\"},\\"body\\":{\\"objectJson\\":\\"{TIMESTAMP,\\"type\\":\\"sessionStorage\\",\\"tagName\\":\\"\\",\\"id\\":\\"test\\",\\"nodeName\\":\\"\\",\\"url\\":\\"http://localhost:1801/webpages/sessionStorage.html\\",\\"text\\":\\"sessionData\\"}\\",\\"apikey\\":\\"not set\\"}}"]';
-      expect(JSON.stringify(Array.from(actualData))).toBe(expectedData);
+        '"{\\"action\\":{\\"action\\":\\"reportObject\\"},\\"body\\":{\\"objectJson\\":\\"{TIMESTAMP,\\"type\\":\\"sessionStorage\\",\\"tagName\\":\\"\\",\\"id\\":\\"test\\",\\"nodeName\\":\\"\\",\\"url\\":\\"http://localhost:1801/webpages/sessionStorage.html\\",\\"text\\":\\"sessionData\\"}\\",\\"apikey\\":\\"not set\\"}}"';
+      expect(JSON.stringify(Array.from(actualData))).toContain(expectedData);
+    });
+
+    test('Should record set localStorage with page open', async () => {
+      // Given / When
+      server = getFakeZapServer(actualData, _JSONPORT, true);
+      const context = await driver.getContext(_JSONPORT);
+      const page = await context.newPage();
+      await page.goto(
+        `http://localhost:${_HTTPPORT}/webpages/localStorageDelay.html`
+      );
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(2000);
+      // Then
+      const expectedData =
+        '"{\\"action\\":{\\"action\\":\\"reportObject\\"},\\"body\\":{\\"objectJson\\":\\"{TIMESTAMP,\\"type\\":\\"localStorage\\",\\"tagName\\":\\"\\",\\"id\\":\\"test\\",\\"nodeName\\":\\"\\",\\"url\\":\\"http://localhost:1801/webpages/localStorageDelay.html\\",\\"text\\":\\"localData\\"}\\",\\"apikey\\":\\"not set\\"}}"';
+      expect(JSON.stringify(Array.from(actualData))).toContain(expectedData);
+      // Tidy up
+      await page.close();
+    });
+
+    test('Should record set sessionStorage with page open', async () => {
+      // Given / When
+      server = getFakeZapServer(actualData, _JSONPORT);
+      const context = await driver.getContext(_JSONPORT);
+      const page = await context.newPage();
+      await page.goto(
+        `http://localhost:${_HTTPPORT}/webpages/sessionStorageDelay.html`
+      );
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(2000);
+      // Then
+      const expectedData =
+        '"{\\"action\\":{\\"action\\":\\"reportObject\\"},\\"body\\":{\\"objectJson\\":\\"{TIMESTAMP,\\"type\\":\\"sessionStorage\\",\\"tagName\\":\\"\\",\\"id\\":\\"test\\",\\"nodeName\\":\\"\\",\\"url\\":\\"http://localhost:1801/webpages/sessionStorageDelay.html\\",\\"text\\":\\"sessionData\\"}\\",\\"apikey\\":\\"not set\\"}}"';
+      expect(JSON.stringify(Array.from(actualData))).toContain(expectedData);
+      // Tidy up
+      await page.close();
     });
 
     test('Should record dup added link once ', async () => {

--- a/test/ContentScript/webpages/localStorageDelay.html
+++ b/test/ContentScript/webpages/localStorageDelay.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Document</title>
+</head>
+<body>
+    <script>
+    setInterval(() => {
+        localStorage.setItem("test", "localData");
+    }, 1000);
+    </script>
+</body>
+</html>

--- a/test/ContentScript/webpages/sessionStorageDelay.html
+++ b/test/ContentScript/webpages/sessionStorageDelay.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Document</title>
+</head>
+<body>
+    <script>
+        setInterval(() => {
+        	sessionStorage.setItem("test", "sessionData");
+        }, 1000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
We currently check for storage changes on page load and unload .. which doesnt work so well for modern apps.
Simple example - login to Juice Shop, data is set in local and session storage but we only get to see it when the browser is closed or navigates to a completely new page.
Detecting URL changes appears to be very hard, so polling seems to be a lesser evil.
I wasnt able to work out a good integration test, suggestions appreciated..