### PR TITLE
Update playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "json-server": "^0.17.3",
     "mini-css-extract-plugin": "^1.6.0",
     "optimize-css-assets-webpack-plugin": "^6.0.1",
-    "playwright": "^1.33.0",
+    "playwright": "1.37",
     "playwright-webextext": "^0.0.3",
     "postcss": "^8.4.31",
     "postcss-loader": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6767,10 +6767,10 @@ pkg-dir@^7.0.0:
   dependencies:
     find-up "^6.3.0"
 
-playwright-core@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
-  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
+playwright-core@1.37.1:
+  version "1.37.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.37.1.tgz#cb517d52e2e8cb4fa71957639f1cd105d1683126"
+  integrity sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==
 
 playwright-core@1.50.1:
   version "1.50.1"
@@ -6782,6 +6782,13 @@ playwright-webextext@^0.0.3:
   resolved "https://registry.yarnpkg.com/playwright-webextext/-/playwright-webextext-0.0.3.tgz#8f809a439c976dd71a7a4d2f711b01a10d910a8a"
   integrity sha512-qcnMZES3vbnEfCrOobsaFrT+BBlRgCmKBCzhoRxPkdC9C5KSOYdROikuTHRoe/ez5v1Eh02szQjwRBStOkDF6g==
 
+playwright@1.37:
+  version "1.37.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.37.1.tgz#6e488d82d7d98b9127c5db9c701f9c956ab47e76"
+  integrity sha512-bgUXRrQKhT48zHdxDYQTpf//0xDfDd5hLeEhjuSw8rXEGoT9YeElpfvs/izonTNY21IQZ7d3s22jLxYaAnubbQ==
+  dependencies:
+    playwright-core "1.37.1"
+
 playwright@1.50.1:
   version "1.50.1"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.50.1.tgz#2f93216511d65404f676395bfb97b41aa052b180"
@@ -6790,13 +6797,6 @@ playwright@1.50.1:
     playwright-core "1.50.1"
   optionalDependencies:
     fsevents "2.3.2"
-
-playwright@^1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.33.0.tgz#88df1cffe97718ab8a02303e12c9133681ec7fab"
-  integrity sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==
-  dependencies:
-    playwright-core "1.33.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
~Binary chopping between 1.33.0 (0k) and 1.50 (fail). Already know 1.40 fails.
Once we know which release actually causes the break we can then check the release notes..