### PR TITLE
Dont update playwright for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       patterns:
       - "*"
   open-pull-requests-limit: 10
+  ignore:
+    # Playwright updates break the tests - TODO fix them!
+    - dependency-name: "playwright*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Hopefully got this right, as per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#disabling-dependabot-version-updates