### PR TITLE
Fix download on script completion on Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the full browser extension will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+- Download on script completion on Chrome.
+- Download file date string.
+
 ## 0.1.2 - 2025-06-17
 
 ### Added

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -3,6 +3,12 @@ All notable changes to the recorder browser extension will be documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+- Download on script completion on Chrome.
+- Download file date string.
+
 ## 0.1.2 - 2025-06-17
 
 ### Added

--- a/source/Background/index.ts
+++ b/source/Background/index.ts
@@ -23,7 +23,6 @@ import {ReportedStorage} from '../types/ReportedModel';
 import {ZestScript, ZestScriptMessage} from '../types/zestScript/ZestScript';
 import {ZestStatementWindowClose} from '../types/zestScript/ZestStatement';
 import {
-  DOWNLOAD_RECORDING,
   GET_ZEST_SCRIPT,
   IS_FULL_EXTENSION,
   LOCAL_STORAGE,
@@ -173,33 +172,6 @@ function sendZestScriptToZAP(
   }
 }
 
-function downloadZestScript(zestScriptJSON: string, title: string): void {
-  const blob = new Blob([zestScriptJSON], {type: 'application/json'});
-  const url = URL.createObjectURL(blob);
-
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = title + (title.slice(-4) === '.zst' ? '' : '.zst');
-  link.style.display = 'none';
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  URL.revokeObjectURL(url);
-}
-
-function pad(i: number): string {
-  return `${i}`.padStart(2, `0`);
-}
-
-function getDateString(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${pad(now.getMonth())}-${pad(
-    now.getDay()
-  )}-${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
-}
-
 async function handleMessage(
   request: MessageEvent,
   zapurl: string,
@@ -275,17 +247,6 @@ async function handleMessage(
           sendZestScriptToZAP(data, zapkey, zapurl);
         }
       }
-      break;
-    }
-    case DOWNLOAD_RECORDING: {
-      zestScript.getZestScript().then((items) => {
-        const msg = items as ZestScriptMessage;
-        let site = '';
-        if (request.data) {
-          site = `${request.data}-`;
-        }
-        downloadZestScript(msg.script, `zap-rec-${site}${getDateString()}.zst`);
-      });
       break;
     }
     case SET_SAVE_SCRIPT_ENABLE:

--- a/source/Popup/index.tsx
+++ b/source/Popup/index.tsx
@@ -31,6 +31,7 @@ import {
   ZAP_START_RECORDING,
   ZAP_STOP_RECORDING,
 } from '../utils/constants';
+import {downloadJson} from '../utils/util';
 import {ZestScriptMessage} from '../types/zestScript/ZestScript';
 
 const STOP = i18n.t('stop');
@@ -193,19 +194,11 @@ function downloadZestScript(zestScriptJSON: string, title: string): void {
     scriptNameInput?.focus();
     return;
   }
-  const blob = new Blob([zestScriptJSON], {type: 'application/json'});
-  const url = URL.createObjectURL(blob);
+  downloadJson(
+    zestScriptJSON,
+    title + (title.slice(-4) === '.zst' ? '' : '.zst')
+  );
 
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = title + (title.slice(-4) === '.zst' ? '' : '.zst');
-  link.style.display = 'none';
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  URL.revokeObjectURL(url);
   Browser.runtime.sendMessage({type: RESET_ZEST_SCRIPT});
   Browser.storage.sync.set({
     zaprecordingactive: false,

--- a/source/utils/constants.ts
+++ b/source/utils/constants.ts
@@ -41,7 +41,6 @@ export const ZAP_START_RECORDING = 'zapStartRecording';
 export const SET_SAVE_SCRIPT_ENABLE = 'setSaveScriptEnable';
 export const ZEST_SCRIPT = 'zestScript';
 
-export const DOWNLOAD_RECORDING = 'downloadRecording';
 export const STOP_RECORDING = 'stopRecording';
 export const RESET_ZEST_SCRIPT = 'resetZestScript';
 export const GET_ZEST_SCRIPT = 'getZestScript';

--- a/source/utils/util.ts
+++ b/source/utils/util.ts
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related source files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function downloadJson(json: string, title: string): void {
+  const blob = new Blob([json], {type: 'application/json'});
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = title;
+  link.style.display = 'none';
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+export {downloadJson};


### PR DESCRIPTION
It turns out that `URL.createObjectURL` does not work in Chrome in the service worker, where we were using it to download the script. It works fine in Firefox, where I do most of my testing :/
Have changed to download the script in the content script.
Manually tested on Chrome and Firefox.
The download button in the popup is still failing in Edge as per #208 - will submit another PR to fix that.