### PR TITLE
Fix download via popup on Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Download on script completion on Chrome.
 - Download file date string.
+- Download via popup on Edge.
+- Close notification dialog when script downloaded directly.
 
 ## 0.1.2 - 2025-06-17
 

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Download on script completion on Chrome.
 - Download file date string.
+- Download via popup on Edge.
+- Close notification dialog when script downloaded directly.
 
 ## 0.1.2 - 2025-06-17
 

--- a/source/Background/index.ts
+++ b/source/Background/index.ts
@@ -30,7 +30,6 @@ import {
   REPORT_OBJECT,
   RESET_ZEST_SCRIPT,
   SESSION_STORAGE,
-  SET_SAVE_SCRIPT_ENABLE,
   STOP_RECORDING,
   ZEST_SCRIPT,
 } from '../utils/constants';
@@ -249,11 +248,6 @@ async function handleMessage(
       }
       break;
     }
-    case SET_SAVE_SCRIPT_ENABLE:
-      Browser.storage.sync.set({
-        zapenablesavescript: zestScript.getZestStatementCount() > 0,
-      });
-      break;
 
     default:
       // Handle unknown request type

--- a/source/Popup/styles.scss
+++ b/source/Popup/styles.scss
@@ -275,11 +275,6 @@ html {
     color: var(--primary);
   }
   &:hover {color: var(--primary);}
-
-  &.disabled {
-    pointer-events: none;
-    opacity: 0.5;
-  }
 }
 
 @keyframes waves {

--- a/source/types/zestScript/ZestScript.ts
+++ b/source/types/zestScript/ZestScript.ts
@@ -22,6 +22,7 @@ import Browser from 'webextension-polyfill';
 interface ZestScriptMessage {
   script: string;
   title: string;
+  statementCount: number;
 }
 
 class ZestScript {
@@ -93,7 +94,11 @@ class ZestScript {
     return new Promise((resolve) => {
       Browser.storage.sync.get({zapscriptname: this.title}).then((items) => {
         this.title = items.zapscriptname as string;
-        resolve({script: this.toJSON(), title: this.title});
+        resolve({
+          script: this.toJSON(),
+          title: this.title,
+          statementCount: this.getZestStatementCount(),
+        });
       });
     });
   }

--- a/source/utils/constants.ts
+++ b/source/utils/constants.ts
@@ -38,7 +38,6 @@ export const DEFAULT_WINDOW_HANDLE = 'windowHandle1';
 
 export const ZAP_STOP_RECORDING = 'zapStopRecording';
 export const ZAP_START_RECORDING = 'zapStartRecording';
-export const SET_SAVE_SCRIPT_ENABLE = 'setSaveScriptEnable';
 export const ZEST_SCRIPT = 'zestScript';
 
 export const STOP_RECORDING = 'stopRecording';


### PR DESCRIPTION
Fixes: #208

The fix is enabling the Download button all of the time, as Chrome and Edge dont get notifications that the popup dialog has been shown.
However the code has been changed to do nothing when that button is clicked if no statements have been recorded.

Also close notification dialog when script downloaded directly.