### PR TITLE
Remove XPath uniqueness post check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the full browser extension will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+- Do not record empty elements.
+
 ## 0.1.3 - 2025-06-18
 
 ### Fixed

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Edge Add-ons Store details.
 
+### Fixed
+- Do not record empty elements.
+
 ## 0.1.3 - 2025-06-18
 
 ### Fixed

--- a/source/ContentScript/util.ts
+++ b/source/ContentScript/util.ts
@@ -141,7 +141,7 @@ function getPath(
       path.element = selector;
     } else {
       const xpath = getXPath(element, documentElement);
-      if (xpath && isElementXPathUnique(xpath, documentElement)) {
+      if (xpath) {
         path.type = 'xpath';
         path.element = xpath;
       }

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -683,6 +683,8 @@ function integrationTests(
     await eventsProcessed();
     await wd.findElement(By.xpath('/html/body/div[3]/button')).click();
     await eventsProcessed();
+    await wd.findElement(By.xpath('/html/body/div[3]/span[1]')).click();
+    await eventsProcessed();
     // Then
     expect(actualData).toEqual([
       reportZestStatementComment(),
@@ -691,6 +693,13 @@ function integrationTests(
       reportZestStatementClick(4, 'btn'),
       reportZestStatementScrollTo(5, '/html/body/div[2]/button', 'xpath', 5000),
       reportZestStatementClick(6, '/html/body/div[2]/button', 'xpath', 10000),
+      reportZestStatementScrollTo(
+        7,
+        '/html/body/div[2]/span[1]',
+        'xpath',
+        5000
+      ),
+      reportZestStatementClick(8, '/html/body/div[2]/span[1]', 'xpath', 10000),
     ]);
   });
 }

--- a/test/ContentScript/webpages/divtest.html
+++ b/test/ContentScript/webpages/divtest.html
@@ -2,16 +2,25 @@
 <html>
 <body>
 <script>
-function addButton() {
+function addElements() {
 	const div = document.createElement('div');
 	const button = document.createElement('button');
     button.textContent = 'Click Me';
 	div.appendChild(button);
+
+	const spanA = document.createElement('span');
+	spanA.textContent = 'Span A';
+	div.appendChild(spanA);
+
+	const spanB = document.createElement('span');
+	spanB.textContent = "Span B";
+	div.appendChild(spanB);
+
 	document.body.appendChild(div);
 }
 </script>
 <div>
-	<button id="btn" onclick="addButton();">Add Button</button>
+	<button id="btn" onclick="addElements();">Add Elements</button>
 </div>
 
 </body>


### PR DESCRIPTION
The path is already being created ensuring the path is unique and checking after might lead to misses since the path created might not match the current state of the page because of the recorder overlay which adds elements that will not be present when replaying.