### PR TITLE
Correct `waitForMsec` for scroll to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Do not record empty elements.
+- Correct `waitForMsec` for synthetic scroll to events.
 
 ## 0.1.3 - 2025-06-18
 

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Do not record empty elements.
+- Correct `waitForMsec` for synthetic scroll to events.
 
 ## 0.1.3 - 2025-06-18
 

--- a/source/ContentScript/recorder.ts
+++ b/source/ContentScript/recorder.ts
@@ -146,7 +146,7 @@ class Recorder {
     console.log(event, 'ZAP clicked');
     const elementLocator = getPath(event.target as HTMLElement, element);
     this.sendZestScriptToZAP(
-      new ZestStatementElementScrollTo(elementLocator, this.getWaited()),
+      new ZestStatementElementScrollTo(elementLocator, waited),
       false
     );
     this.sendZestScriptToZAP(
@@ -198,7 +198,7 @@ class Recorder {
       this.handleCachedSubmit();
     }
     this.sendZestScriptToZAP(
-      new ZestStatementElementScrollTo(elementLocator, this.getWaited()),
+      new ZestStatementElementScrollTo(elementLocator, waited),
       false
     );
     this.sendZestScriptToZAP(

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -260,6 +260,32 @@ function integrationTests(
     ]);
   });
 
+  test('Should record send keys waiting enough', async () => {
+    // Given / When
+    await driver.toggleRecording();
+    const wd = await driver.getWebDriver();
+    await wd.get(`http://localhost:${_HTTPPORT}/webpages/interactions.html`);
+    await pageLoaded(wd);
+    await wd.findElement(By.id('click')).click();
+    await eventsProcessed(5000);
+    await wd.findElement(By.id('input-1')).sendKeys('testinput');
+    await wd.findElement(By.id('click')).click();
+    await eventsProcessed();
+    // Then
+    expect(actualData).toEqual([
+      reportZestStatementComment(),
+      reportZestStatementLaunch(
+        'http://localhost:1801/webpages/interactions.html'
+      ),
+      reportZestStatementScrollTo(3, 'click'),
+      reportZestStatementClick(4, 'click'),
+      reportZestStatementScrollTo(5, 'input-1', 'id', 10000),
+      reportZestStatementSendKeys(6, 'input-1', 'testinput', 'id', 10000),
+      reportZestStatementScrollTo(7, 'click'),
+      reportZestStatementClick(8, 'click'),
+    ]);
+  });
+
   test('Should record appending existing input text', async () => {
     // Given / When
     await driver.toggleRecording();
@@ -691,13 +717,18 @@ function integrationTests(
       reportZestStatementLaunch('http://localhost:1801/webpages/divtest.html'),
       reportZestStatementScrollTo(3, 'btn'),
       reportZestStatementClick(4, 'btn'),
-      reportZestStatementScrollTo(5, '/html/body/div[2]/button', 'xpath', 5000),
+      reportZestStatementScrollTo(
+        5,
+        '/html/body/div[2]/button',
+        'xpath',
+        10000
+      ),
       reportZestStatementClick(6, '/html/body/div[2]/button', 'xpath', 10000),
       reportZestStatementScrollTo(
         7,
         '/html/body/div[2]/span[1]',
         'xpath',
-        5000
+        10000
       ),
       reportZestStatementClick(8, '/html/body/div[2]/span[1]', 'xpath', 10000),
     ]);

--- a/test/ContentScript/utils.ts
+++ b/test/ContentScript/utils.ts
@@ -231,13 +231,17 @@ export function reportZestStatementSubmit(
 export function reportZestStatementSendKeys(
   index: number,
   element: string,
-  value: string
+  value: string,
+  statementType = 'id',
+  wait = 5000
 ): object {
   return reportZestStatement(
     index,
     'ZestClientElementSendKeys',
     element,
-    value
+    value,
+    statementType,
+    wait
   );
 }
 
@@ -266,9 +270,9 @@ export function reportZestStatementSwitchToFrame(
   return data;
 }
 
-export async function eventsProcessed(): Promise<void> {
+export async function eventsProcessed(delay = TIMEOUT): Promise<void> {
   return new Promise((f) => {
-    setTimeout(f, TIMEOUT);
+    setTimeout(f, delay);
   });
 }
 


### PR DESCRIPTION
Since scroll to events are synthetic they should take into account the original time for the actual event being recorded (e.g. click), otherwise when replaying it will fail to wait the required time for the element to be actionable.