### PR TITLE
Record submitted inputs in mutated frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correct the position of the notification dialog when the page being recorded uses frames.
+- Record submitted inputs dynamically added to frames.
 
 ## 0.1.4 - 2025-06-30
 

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correct the position of the notification dialog when the page being recorded uses frames.
+- Record submitted inputs dynamically added to frames.
 
 ## 0.1.4 - 2025-06-30
 

--- a/source/ContentScript/recorder.ts
+++ b/source/ContentScript/recorder.ts
@@ -312,9 +312,12 @@ class Recorder {
     const domMutated: MutationCallback = (mutationsList: MutationRecord[]) => {
       mutationsList.forEach((mutation) => {
         if (mutation.type === 'childList') {
-          // Look for added input elements
-          if (mutation.target instanceof Element) {
-            const inputs = mutation.target.getElementsByTagName('input');
+          // Use node type instead of instanceof as it does not work reliably
+          if (mutation.target.nodeType === Node.ELEMENT_NODE) {
+            // Look for added input elements
+            const inputs = (mutation.target as Element).getElementsByTagName(
+              'input'
+            );
             for (let j = 0; j < inputs.length; j += 1) {
               this.addListenerToInputField(
                 textElements,
@@ -330,7 +333,7 @@ class Recorder {
     };
 
     const observer = new MutationObserver(domMutated);
-    observer.observe(document, {
+    observer.observe(element, {
       attributes: false,
       childList: true,
       subtree: true,

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -542,6 +542,36 @@ function integrationTests(
     ]);
   });
 
+  test('Should record frame submitted elements', async () => {
+    // Given / When
+    await driver.toggleRecording();
+    const wd = await driver.getWebDriver();
+    await wd.get(`http://localhost:${_HTTPPORT}/webpages/frameset.html`);
+    await wd.switchTo().frame(0);
+    await wd.findElement(By.id('btn')).click();
+    const inputA = await wd.findElement(By.xpath('/html/body/div[2]/input'));
+    await inputA.sendKeys('value');
+    await inputA.sendKeys(Key.ENTER);
+    await eventsProcessed();
+    // Then
+    expect(actualData).toEqual([
+      reportZestStatementComment(),
+      reportZestStatementLaunch('http://localhost:1801/webpages/frameset.html'),
+      reportZestStatementSwitchToFrame(3, 0, ''),
+      reportZestStatementScrollTo(4, 'btn'),
+      reportZestStatementClick(5, 'btn'),
+      reportZestStatementScrollTo(6, 'body > div > input', 'cssSelector'),
+      reportZestStatementSendKeys(
+        7,
+        'body > div > input',
+        'value',
+        'cssSelector'
+      ),
+      reportZestStatementScrollTo(8, 'body > div > input', 'cssSelector'),
+      reportZestStatementSubmit(9, 'body > div > input', 'cssSelector'),
+    ]);
+  });
+
   test('Should not record interactions on floating container', async () => {
     // Given / When
     await driver.toggleRecording();

--- a/test/ContentScript/utils.ts
+++ b/test/ContentScript/utils.ts
@@ -218,13 +218,17 @@ export function reportZestStatementClick(
 
 export function reportZestStatementSubmit(
   index: number,
-  element: string
+  element: string,
+  statementType = 'id',
+  wait = 5000
 ): object {
   return reportZestStatement(
     index,
     'ZestClientElementSubmit',
     element,
-    undefined
+    undefined,
+    statementType,
+    wait
   );
 }
 

--- a/test/ContentScript/webpages/divtest.html
+++ b/test/ContentScript/webpages/divtest.html
@@ -16,6 +16,10 @@ function addElements() {
 	spanB.textContent = "Span B";
 	div.appendChild(spanB);
 
+	const input = document.createElement('input');
+	input.type = "text";
+	div.appendChild(input);
+
 	document.body.appendChild(div);
 }
 </script>


### PR DESCRIPTION
Correct the element to be observed.
Change `instanceof` to node type check since that was not working for all elements.