### PR TITLE
Fix recording of frames not immediately loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Include start URL loading time in `waitForMsec` of the first recorded action.
 - Correct the position of the notification dialog when the page being recorded uses frames.
 - Record submitted inputs dynamically added to frames.
+- Correct recording of frames not immediately loaded.
 
 ## 0.1.4 - 2025-06-30
 

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Include start URL loading time in `waitForMsec` of the first recorded action.
 - Correct the position of the notification dialog when the page being recorded uses frames.
 - Record submitted inputs dynamically added to frames.
+- Correct recording of frames not immediately loaded.
 
 ## 0.1.4 - 2025-06-30
 

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -592,6 +592,26 @@ function integrationTests(
     ]);
   });
 
+  test('Should record frame interactions on delayed loaded frame', async () => {
+    // Given / When
+    await driver.toggleRecording();
+    const wd = await driver.getWebDriver();
+    await wd.get(`http://localhost:${_HTTPPORT}/webpages/framesetDelay.html`);
+    await wd.wait(until.ableToSwitchToFrame(0));
+    await wd.wait(until.elementLocated(By.id('btn'))).click();
+    await eventsProcessed();
+    // Then
+    expect(actualData).toEqual([
+      reportZestStatementComment(),
+      reportZestStatementLaunch(
+        'http://localhost:1801/webpages/framesetDelay.html'
+      ),
+      reportZestStatementSwitchToFrame(3, 0, ''),
+      reportZestStatementScrollTo(4, 'btn'),
+      reportZestStatementClick(5, 'btn'),
+    ]);
+  });
+
   test('Should not record interactions on floating container', async () => {
     // Given / When
     await driver.toggleRecording();

--- a/test/ContentScript/webpages/framesetDelay.html
+++ b/test/ContentScript/webpages/framesetDelay.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <frameset>
+        <frame src="divtest.html?delay"></frame>
+    </frameset>
+</html>


### PR DESCRIPTION
Wait for the frame to be fully loaded, if not already, to add the recorder listeners.