### PR TITLE
Include start URL loading time in first action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Fixed
+- Include start URL loading time in `waitForMsec` of the first recorded action.
 - Correct the position of the notification dialog when the page being recorded uses frames.
 
 ## 0.1.4 - 2025-06-30

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Fixed
+- Include start URL loading time in `waitForMsec` of the first recorded action.
 - Correct the position of the notification dialog when the page being recorded uses frames.
 
 ## 0.1.4 - 2025-06-30

--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -277,14 +277,15 @@ function injectScript(): Promise<boolean> {
     configureExtension();
     withZapRecordingActive(() => {
       Browser.storage.sync
-        .get({initScript: false, loginUrl: ''})
+        .get({initScript: false, loginUrl: '', startTime: 0})
         .then((items) => {
           console.log(
             `ZAP injectScript items ${items.initScript} ${items.loginUrl}`
           );
           recorder.recordUserInteractions(
             items.initScript === true,
-            items.loginUrl as string
+            items.loginUrl as string,
+            items.startTime as number
           );
         });
     });

--- a/source/ContentScript/recorder.ts
+++ b/source/ContentScript/recorder.ts
@@ -354,13 +354,15 @@ class Recorder {
     return browserName;
   }
 
-  initializationScript(loginUrl = ''): void {
+  initializationScript(loginUrl = '', startTime = 0): void {
     console.log(`ZAP initializationScript ${loginUrl}`);
     Browser.storage.sync.set({
       initScript: false,
       loginUrl: '',
+      startTime: 0,
       downloadScript: true,
     });
+    this.lastStatementTime = startTime;
     const stopRecordingButton = document.getElementById(STOP_RECORDING_ID);
     if (stopRecordingButton) {
       // Can happen if recording restarted in browser launched from ZAP recorder
@@ -382,10 +384,14 @@ class Recorder {
     this.handleResize();
   }
 
-  recordUserInteractions(initScript = true, loginUrl = ''): void {
+  recordUserInteractions(
+    initScript = true,
+    loginUrl = '',
+    startTime = 0
+  ): void {
     console.log(`ZAP user interactions ${initScript} ${loginUrl}`);
     if (initScript) {
-      this.initializationScript(loginUrl);
+      this.initializationScript(loginUrl, startTime);
     }
     this.active = true;
     this.previousDOMState = document.documentElement.outerHTML;

--- a/source/Popup/index.tsx
+++ b/source/Popup/index.tsx
@@ -129,6 +129,7 @@ function startRecording(): void {
   Browser.storage.sync.set({
     initScript: true,
     loginUrl: loginUrlInput.value,
+    startTime: loginUrlInput.value !== '' ? Date.now() : 0,
   });
   sendMessageToContentScript(ZAP_START_RECORDING);
   Browser.runtime.sendMessage({type: RESET_ZEST_SCRIPT});

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -238,6 +238,26 @@ function integrationTests(
     ]);
   });
 
+  test('Should record click with start URL delay', async () => {
+    // Given / When
+    await driver.toggleRecording(
+      `http://localhost:${_HTTPPORT}/webpages/interactions.html?delay=5000`
+    );
+    const wd = await driver.getWebDriver();
+    await pageLoaded(wd, 5500);
+    await wd.findElement(By.id('click')).click();
+    await eventsProcessed();
+    // Then
+    expect(actualData).toEqual([
+      reportZestStatementComment(),
+      reportZestStatementLaunch(
+        'http://localhost:1801/webpages/interactions.html?delay=5000'
+      ),
+      reportZestStatementScrollTo(3, 'click', 'id', 10000),
+      reportZestStatementClick(4, 'click', 'id', 10000),
+    ]);
+  });
+
   test('Should record send keys', async () => {
     // Given / When
     await driver.toggleRecording();

--- a/test/drivers/BaseDriver.ts
+++ b/test/drivers/BaseDriver.ts
@@ -66,7 +66,7 @@ abstract class BaseDriver {
 
   private async selectLatestWindow(wd: WebDriver): Promise<void> {
     const handles = await wd.getAllWindowHandles();
-    await wd.switchTo().window(handles[0]);
+    await wd.switchTo().window(handles.at(handles.length > 2 ? -1 : 0));
   }
 
   public async setEnable(value: boolean): Promise<void> {


### PR DESCRIPTION
Allow the page to fully load to replay the first action (e.g. click), otherwise the default five seconds are not enough for sites that take longer to load (e.g. redirects/SSO) leading to replay failures.