### PR TITLE
Do not switch frames on mouse over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Do not record frame switches on mouse over events as they are not currently recorded.
+
 ### Fixed
 - Include start URL loading time in `waitForMsec` of the first recorded action.
 - Correct the position of the notification dialog when the page being recorded uses frames.

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Do not record frame switches on mouse over events as they are not currently recorded.
+
 ### Fixed
 - Include start URL loading time in `waitForMsec` of the first recorded action.
 - Correct the position of the notification dialog when the page being recorded uses frames.

--- a/source/ContentScript/recorder.ts
+++ b/source/ContentScript/recorder.ts
@@ -303,10 +303,11 @@ class Recorder {
       'scroll',
       debounce(this.handleScroll.bind(this, {level, frame, element}), 1000)
     );
-    element.addEventListener(
-      'mouseover',
-      this.handleMouseOver.bind(this, {level, frame, element})
-    );
+    // Do not track mouse over events for now, they are not recorded.
+    // element.addEventListener(
+    //   'mouseover',
+    //   this.handleMouseOver.bind(this, {level, frame, element})
+    // );
     element.addEventListener(
       'change',
       this.handleChange.bind(this, {level, frame, element})


### PR DESCRIPTION
Mouse over events are not currently recorded so there's no need to record the frame switches (other actions already check if the frame switch is needed).