### PR TITLE
Do not fail fast in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         browser: ["Chrome", "Edge", "Firefox"]
 


### PR DESCRIPTION
Allow the integrations tests of each browser to continue regardless.