### PR TITLE
Run CI only on push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: Check CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Do not run CI "twice" when dependabot creates the branches to update the dependencies.