### PR TITLE
Ignore pointer with handled ancestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Report `textarea` and `select` elements.
 - Report interactable state of elements.
 
+### Changed
+- Ignore cursor pointer style elements whose ancestor is already handled (e.g. `a`, `button`), as they should be only for decoration/aesthetic purposes of the latter.
+
 ## 0.1.9 - 2026-05-15
 
 ### Added

--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -26,7 +26,12 @@ import {
   InteractableState,
 } from '../types/ReportedModel';
 import Recorder from './recorder';
-import {hasPointerStyle, getInteractableState} from './util';
+import {
+  hasPointerStyle,
+  getInteractableState,
+  hasInteractableTagAncestor,
+  INTERACTABLE_TAG_NAMES,
+} from './util';
 import {
   IS_FULL_EXTENSION,
   LOCAL_STORAGE,
@@ -214,12 +219,9 @@ function reportPointerElements(
     const {tagName} = element;
     const url = window.location.href;
     if (
-      tagName !== 'input' &&
-      tagName !== 'textarea' &&
-      tagName !== 'select' &&
-      tagName !== 'button' &&
-      tagName !== 'a' &&
-      element instanceof Element
+      !INTERACTABLE_TAG_NAMES.has(tagName) &&
+      element instanceof Element &&
+      !hasInteractableTagAncestor(element)
     ) {
       if (hasPointerStyle(element)) {
         const re = new ReportedElement(element, url);

--- a/source/ContentScript/util.ts
+++ b/source/ContentScript/util.ts
@@ -188,6 +188,28 @@ function getPath(
   return path;
 }
 
+const INTERACTABLE_TAG_NAMES = new Set([
+  'INPUT',
+  'TEXTAREA',
+  'SELECT',
+  'BUTTON',
+  'A',
+]);
+
+function hasInteractableTagAncestor(el: Element): boolean {
+  let parent = el.parentElement;
+  let depth = 0;
+  // Do not traverse the whole tree.
+  while (parent && depth < 15) {
+    if (INTERACTABLE_TAG_NAMES.has(parent.tagName)) {
+      return true;
+    }
+    parent = parent.parentElement;
+    depth += 1;
+  }
+  return false;
+}
+
 function hasPointerStyle(el: Element): boolean {
   const compStyles = window.getComputedStyle(el, 'hover');
   return compStyles.getPropertyValue('cursor') === 'pointer';
@@ -237,6 +259,8 @@ export {
   getPath,
   hasPointerStyle,
   getInteractableState,
+  hasInteractableTagAncestor,
+  INTERACTABLE_TAG_NAMES,
   markClassAsDynamic,
   safeXPathString,
   snapshotInputClass,

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -1076,6 +1076,66 @@ function integrationTests(
     ]);
   });
 
+  test('Should not report pointer elements with interactable tag ancestor', async () => {
+    // Given
+    await enableZapEvents(server, driver);
+    server.setRecordZapEvents(false);
+    const wd = await driver.getWebDriver();
+    const url = `http://localhost:${_HTTPPORT}/webpages/pointerelementsparent.html`;
+    // When
+    await wd.get(url);
+    await eventsProcessed();
+    // Then
+    expect(actualData).toEqual([
+      reportEvent('pageLoad', url),
+      reportObject('nodeAdded', 'A', '', 'A', url, `${url}#`, 'link child', {
+        interactable: {visible: true, enabled: true, pointer: true},
+      }),
+      reportObject(
+        'nodeAdded',
+        'BUTTON',
+        'btn-deep',
+        'BUTTON',
+        url,
+        undefined,
+        'deep',
+        {interactable: {visible: true, enabled: true, pointer: false}}
+      ),
+      reportObject(
+        'nodeAdded',
+        'BUTTON',
+        'btn-outer',
+        'BUTTON',
+        url,
+        undefined,
+        'beyond',
+        {interactable: {visible: true, enabled: true, pointer: false}}
+      ),
+      reportObject(
+        'nodeAdded',
+        'DIV',
+        'div1',
+        'DIV',
+        url,
+        undefined,
+        'Standalone',
+        {
+          interactable: {visible: true, enabled: true, pointer: true},
+        }
+      ),
+      reportObject(
+        'nodeAdded',
+        'SPAN',
+        'span-beyond-limit',
+        'SPAN',
+        url,
+        undefined,
+        'beyond',
+        {interactable: {visible: true, enabled: true, pointer: true}}
+      ),
+    ]);
+  });
+
   test('Should report textarea', async () => {
     // Given
     await enableZapEvents(server, driver);

--- a/test/ContentScript/webpages/pointerelementsparent.html
+++ b/test/ContentScript/webpages/pointerelementsparent.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+.pointer {
+	cursor: pointer
+}
+</style>
+<div id="div1" class="pointer">Standalone</div>
+<a href="#"><span id="span-in-link" class="pointer">link child</span></a>
+<button id="btn-deep"><div><div><div><span id="span-deep-in-button" class="pointer">deep</span></div></div></div></button>
+<button id="btn-outer"><div><div><div><div><div><div><div><div><div><div><div><div><div><div><div><span id="span-beyond-limit" class="pointer">beyond</span></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></button>
+</body>
+</html>


### PR DESCRIPTION
Ignore cursor pointer style elements whose ancestor is already handled (e.g. `a`, `button`), as they should be only for decoration/aesthetic purposes of the latter.