### PR TITLE
Allow access to extension pages in Firefox 153+

### DIFF
--- a/test/drivers/FirefoxDriver.ts
+++ b/test/drivers/FirefoxDriver.ts
@@ -41,9 +41,13 @@ class FirefoxDriver extends BaseDriver {
         })
       )
       .addArguments('-headless');
+    const service = new firefox.ServiceBuilder().addArguments(
+      '--allow-system-access'
+    );
     const wd = (await new Builder()
       .forBrowser(Browser.FIREFOX)
       .setFirefoxOptions(options)
+      .setFirefoxService(service)
       .build()) as firefox.Driver;
     wd.installAddon(`${extensionPath.FIREFOX}.ext.xpi`, true);
     return wd;


### PR DESCRIPTION
Add the necessary service flag to keep the access to extension pages.

---
https://firefox-source-docs.mozilla.org/testing/geckodriver/Flags.html#allow-system-access
e.g.:
```
  ● Firefox Integration Test › Should stop recording

    UnsupportedOperationError: Navigation to "moz-extension://5f271647-ec19-47f5-bb19-d646f523c873/options.html" is not allowed in this context

      at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:523:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:526:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:458:28)
      at Driver.execute (node_modules/selenium-webdriver/lib/webdriver.js:745:17)
```