### PR TITLE
Signal configuration and do not set default in SW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the full browser extension will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.2 - 2026-08-14
+### Fixed
+- Correct and signal when auto-configuration is done.
+
 ## 0.2.1 - 2026-08-10
 ### Fixed
 - Handle cross-origin frames.

--- a/source/Background/index.ts
+++ b/source/Background/index.ts
@@ -305,10 +305,6 @@ if (IS_FULL_EXTENSION) {
 
   Browser.runtime.onInstalled.addListener((): void => {
     console.emoji('🦄', 'extension installed');
-    Browser.storage.sync.set({
-      zapurl: 'http://zap/',
-      zapkey: 'not set',
-    });
   });
 }
 

--- a/source/ContentScript/index.ts
+++ b/source/ContentScript/index.ts
@@ -36,6 +36,7 @@ import {
 import {
   IS_FULL_EXTENSION,
   LOCAL_STORAGE,
+  LOCAL_ZAP_CONFIGURED,
   LOCAL_ZAP_ENABLE,
   LOCAL_ZAP_RECORD,
   REPORT_EVENT,
@@ -368,7 +369,7 @@ function enableExtension(): void {
   reportPageLoaded(document, reportObject);
 }
 
-function configureExtension(): void {
+async function configureExtension(): Promise<void> {
   if (isConfigurationRequest()) {
     // The Browser has been launched from ZAP - use this URL for configuration
     const params = new URLSearchParams(window.location.search);
@@ -380,37 +381,44 @@ function configureExtension(): void {
       params.has(URL_ZAP_RECORD);
 
     console.log('ZAP Configure', enable, record);
-    Browser.storage.sync.set({
-      zapurl: window.location.href.split('?')[0],
-      zapenable: enable,
-      zaprecordingactive: record,
-    });
+    try {
+      await Browser.storage.sync.set({
+        zapurl: window.location.href.split('?')[0],
+        zapenable: enable,
+        zaprecordingactive: record,
+      });
+    } catch (e) {
+      console.error('ZAP Configure failed to write sync storage', e);
+      return;
+    }
+    try {
+      localStorage.setItem(LOCAL_ZAP_CONFIGURED, 'true');
+    } catch (e) {
+      console.error('ZAP Configure failed to write localStorage flag', e);
+    }
   }
 }
 
-function injectScript(): Promise<boolean> {
-  return new Promise((resolve) => {
-    configureExtension();
-    withZapRecordingActive(() => {
-      Browser.storage.sync
-        .get({initScript: false, loginUrl: '', startTime: 0})
-        .then((items) => {
-          console.log(
-            `ZAP injectScript items ${items.initScript} ${items.loginUrl}`
-          );
-          recorder.recordUserInteractions(
-            items.initScript === true,
-            items.loginUrl as string,
-            items.startTime as number
-          );
-        });
-    });
-    withZapEnableSetting(() => {
-      enableExtension();
-      resolve(true);
-    });
-    resolve(false);
+async function injectScript(): Promise<boolean> {
+  await configureExtension();
+  withZapRecordingActive(() => {
+    Browser.storage.sync
+      .get({initScript: false, loginUrl: '', startTime: 0})
+      .then((items) => {
+        console.log(
+          `ZAP injectScript items ${items.initScript} ${items.loginUrl}`
+        );
+        recorder.recordUserInteractions(
+          items.initScript === true,
+          items.loginUrl as string,
+          items.startTime as number
+        );
+      });
   });
+  withZapEnableSetting(() => {
+    enableExtension();
+  });
+  return false;
 }
 
 injectScript();

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZAP by Checkmarx Browser Extension",
-  "version": "0.2.1",
+  "version": "0.2.2",
 
   "icons": {
     "16": "assets/icons/zap16x16.png",

--- a/source/utils/constants.ts
+++ b/source/utils/constants.ts
@@ -53,6 +53,7 @@ export const SESSION_STORAGE = 'sessionStorage';
 export const LOCAL_ZAP_URL = 'localzapurl';
 export const LOCAL_ZAP_ENABLE = 'localzapenable';
 export const LOCAL_ZAP_RECORD = 'localzaprecord';
+export const LOCAL_ZAP_CONFIGURED = 'localzapconfigured';
 export const URL_ZAP_ENABLE = 'zapenable';
 export const URL_ZAP_RECORD = 'zaprecord';
 


### PR DESCRIPTION
Allow to programmatically tell if the browser extension was configured and do not set defaults in the ServiceWorker which would reset the configuration.