### PR TITLE
Handle background script unload while recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Record a clear statement before send keys when a text element has a preexisting value.
+- Handle background script unloads while recording, to prevent loss of recorded data.
 
 ## 0.2.2 - 2026-08-14
 ### Fixed

--- a/CHANGELOG.rec.md
+++ b/CHANGELOG.rec.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Record a clear statement before send keys when a text element has a preexisting value.
+- Handle background script unloads while recording, to prevent loss of recorded data.
 
 ## 0.2.1 - 2026-08-10
 ### Fixed

--- a/__mocks__/webextension-polyfill.ts
+++ b/__mocks__/webextension-polyfill.ts
@@ -21,6 +21,25 @@ const mockStorageSyncGet = jest.fn().mockImplementation(() => {
   return Promise.resolve({zapenable: false});
 });
 
+const localStore: Record<string, unknown> = {};
+
+const mockStorageLocalGet = jest
+  .fn()
+  .mockImplementation((defaults: Record<string, unknown>) => {
+    const result: Record<string, unknown> = {...defaults};
+    for (const key of Object.keys(defaults)) {
+      if (key in localStore) result[key] = localStore[key];
+    }
+    return Promise.resolve(result);
+  });
+
+const mockStorageLocalSet = jest
+  .fn()
+  .mockImplementation((items: Record<string, unknown>) => {
+    Object.assign(localStore, items);
+    return Promise.resolve();
+  });
+
 const Browser = {
   runtime: {
     sendMessage: jest.fn(),
@@ -34,6 +53,10 @@ const Browser = {
   storage: {
     sync: {
       get: mockStorageSyncGet,
+    },
+    local: {
+      get: mockStorageLocalGet,
+      set: mockStorageLocalSet,
     },
   },
   cookies: {

--- a/source/Background/index.ts
+++ b/source/Background/index.ts
@@ -41,6 +41,14 @@ console.log('ZAP Service Worker 👋');
 */
 const reportedStorage = new Set<string>();
 const zestScript = new ZestScript();
+const restorePromise = Browser.storage.local
+  .get({zestStatements: [], zestCurIndex: 1})
+  .then((saved) => {
+    zestScript.restoreStatements(
+      saved.zestStatements as string[],
+      saved.zestCurIndex as number
+    );
+  });
 /*
   A callback URL will only be available if the browser has been launched from ZAP, otherwise call the individual endpoints
 */
@@ -176,6 +184,7 @@ async function handleMessage(
   zapurl: string,
   zapkey: string
 ): Promise<boolean | ZestScriptMessage> {
+  await restorePromise;
   console.log(`ZAP Service worker calling ZAP on ${zapurl}`);
   console.log(zapApiUrl(zapurl, REPORT_OBJECT));
   console.log(encodeURIComponent(zapkey));
@@ -225,6 +234,10 @@ async function handleMessage(
     case ZEST_SCRIPT: {
       const data = zestScript.addStatement(request.data);
       sendZestScriptToZAP(data, zapkey, zapurl);
+      Browser.storage.local.set({
+        zestStatements: zestScript.getStatements(),
+        zestCurIndex: zestScript.getCurIndex(),
+      });
       break;
     }
 
@@ -233,6 +246,7 @@ async function handleMessage(
 
     case RESET_ZEST_SCRIPT:
       zestScript.reset();
+      Browser.storage.local.set({zestStatements: [], zestCurIndex: 1});
       break;
 
     case STOP_RECORDING: {
@@ -244,6 +258,10 @@ async function handleMessage(
           const stmt = new ZestStatementWindowClose(0);
           const data = zestScript.addStatement(stmt.toJSON());
           sendZestScriptToZAP(data, zapkey, zapurl);
+          Browser.storage.local.set({
+            zestStatements: zestScript.getStatements(),
+            zestCurIndex: zestScript.getCurIndex(),
+          });
         }
       }
       break;

--- a/source/types/zestScript/ZestScript.ts
+++ b/source/types/zestScript/ZestScript.ts
@@ -57,6 +57,19 @@ class ZestScript {
     this.curIndex = 1;
   }
 
+  getStatements(): string[] {
+    return [...this.zestStatements];
+  }
+
+  getCurIndex(): number {
+    return this.curIndex;
+  }
+
+  restoreStatements(statements: string[], curIndex: number): void {
+    this.zestStatements = statements;
+    this.curIndex = curIndex;
+  }
+
   getZestStatementCount(): number {
     return this.zestStatements.length;
   }

--- a/test/ContentScript/integrationTests.test.ts
+++ b/test/ContentScript/integrationTests.test.ts
@@ -877,6 +877,41 @@ function integrationTests(
     );
   });
 
+  test('Should preserve recorded statements after period of inactivity', async () => {
+    // Given
+    await driver.toggleRecording();
+    const wd = await driver.getWebDriver();
+    await wd.get(await driver.getPopupURL());
+    await wd.findElement(By.id('script-name-input')).sendKeys('inactivity');
+    await wd.get(`http://localhost:${_HTTPPORT}/webpages/interactions.html`);
+    await eventsProcessed();
+
+    // When
+    await wd.findElement(By.id('input-1')).sendKeys('inactivity');
+    // Inactivity…
+    await eventsProcessed(35000);
+    await wd.findElement(By.id('click')).click();
+    await eventsProcessed();
+    await wd.get(await driver.getPopupURL());
+    await wd.findElement(By.id('save-script')).click();
+    await eventsProcessed();
+
+    // Then
+    const script = JSON.parse(readDownloadedScript(downloadsDir.path));
+    const types: string[] = script.statements.map(
+      (s: {elementType: string}) => s.elementType
+    );
+    expect(types).toEqual([
+      'ZestComment',
+      'ZestClientLaunch',
+      'ZestClientElementScrollTo',
+      'ZestClientElementSendKeys',
+      'ZestClientElementScrollTo',
+      'ZestClientElementClick',
+      'ZestClientWindowClose',
+    ]);
+  }, 60000);
+
   test('Should send window handle close script when enabled', async () => {
     // Given
     await driver.toggleRecording();


### PR DESCRIPTION
Keep the recorded statements in local storage to be able to save them later even if the background script unloads (e.g. due inactivity).