### PR TITLE
Alias resolve-url-loader to the Stackline continuation

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "postcss": "^8.5.26",
     "postcss-loader": "^8.2.1",
     "prettier": "^3.9.6",
-    "resolve-url-loader": "^5.0.0",
+    "resolve-url-loader": "npm:@stackline/resolve-url-loader@1.0.0",
     "sass": "^1.103.1",
     "sass-loader": "^17.0.0",
     "selenium-webdriver": "^4.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,14 +2531,6 @@ acorn@^8.14.0, acorn@^8.16.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
-adjust-sourcemap-loader@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz#fc4a0fd080f7d10471f30a7320f25560ade28c99"
-  integrity sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==
-  dependencies:
-    loader-utils "^2.0.0"
-    regex-parser "^2.2.11"
-
 advanced-css-reset@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/advanced-css-reset/-/advanced-css-reset-2.1.3.tgz#4880fa23bf34d4a195c44c20607e7907d25bd02e"
@@ -3405,11 +3397,6 @@ content-type@^1.0.5, content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
-
-convert-source-map@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -6402,7 +6389,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-loader-utils@^2.0.0, loader-utils@^2.0.4:
+loader-utils@2.0.4, loader-utils@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
@@ -7447,7 +7434,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.2.1, postcss@^8.2.14, postcss@^8.4.40, postcss@^8.5.26:
+postcss@8.5.26, postcss@^8.2.1, postcss@^8.4.40, postcss@^8.5.26:
   version "8.5.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
   integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
@@ -7707,7 +7694,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regex-parser@^2.2.11:
+regex-parser@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.3.1.tgz#ee3f70e50bdd81a221d505242cb9a9c275a2ad91"
   integrity sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==
@@ -7820,15 +7807,14 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve-url-loader@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz#ee3142fb1f1e0d9db9524d539cfa166e9314f795"
-  integrity sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==
+"resolve-url-loader@npm:@stackline/resolve-url-loader@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stackline/resolve-url-loader/-/resolve-url-loader-1.0.0.tgz#1b1856e5aeef738732137856617fecd5b525baf5"
+  integrity sha512-Mh+uYL0+mt7MQG+xoZNAsST/Odol+f5IMh4/Tt6yB3Ch37n17ML7mhnVw7C6wvcykJI63qeC9I7oYMil3/KW/g==
   dependencies:
-    adjust-sourcemap-loader "^4.0.0"
-    convert-source-map "^1.7.0"
-    loader-utils "^2.0.0"
-    postcss "^8.2.14"
+    loader-utils "2.0.4"
+    postcss "8.5.26"
+    regex-parser "2.3.1"
     source-map "0.6.1"
 
 resolve@^1.10.1, resolve@^1.20.0, resolve@^1.22.10, resolve@^1.22.4:


### PR DESCRIPTION
This updates the Sass loader chain's existing `resolve-url-loader` dependency without changing `webpack.config.js` or its historical `require.resolve('resolve-url-loader')` lookup. The manifest keeps that dependency key and points it to the exact npm alias `npm:@stackline/resolve-url-loader@1.0.0`; `yarn.lock` records the corresponding immutable registry artifact.

The concrete use is the loader entry at `webpack.config.js:127`, between `css-loader` and `sass-loader`. The compatibility continuation preserves the callable CommonJS loader, its existing options and deep entries, Webpack 4/5 behavior, and Node 12+ support. This is a maintenance-continuity change, not a vulnerability fix.

Validation on Node 24.19.0 and Yarn 1.22.22:

- `yarn install --frozen-lockfile`
- `yarn lint`
- `yarn test unitTests --runInBand` — 2 suites, 27 tests passed
- `yarn run build` — all six full/recorder Chrome, Firefox, and Opera production bundles passed
- focused installed-package smoke — historical-key require, callable root, five helper functions, and deep `lib/value-processor.js` entry passed

The two Webpack output hashes matched the clean baseline. Existing lint warnings about the TypeScript parser range/React detection and the existing Webpack `optimizeChunkAssets` deprecation remain unchanged. I could not reproduce the repository's full Edge/Firefox integration matrix locally; repository CI remains the authority for that matrix. A clean baseline Chrome integration run had one intermittent frame-event case out of 66, and that exact case passed immediately in isolation.

Disclosure: I (`alexandroit`) maintain the independent `@stackline/resolve-url-loader` package proposed here. I am not affiliated with ZAP or the original `resolve-url-loader` maintainers.

References:

- npm: https://www.npmjs.com/package/@stackline/resolve-url-loader
- source: https://github.com/alexandroit/stackline-resolve-url-loader
- immutable release: https://github.com/alexandroit/stackline-resolve-url-loader/releases/tag/stackline-v1.0.0
